### PR TITLE
Added variable default for ROLE_ARN and option ROLE_PROFILE variable

### DIFF
--- a/assume-aws-role.sh
+++ b/assume-aws-role.sh
@@ -16,8 +16,15 @@
 #  jq: https://stedolan.github.io/jq/
 
 
-ROLE_ARN=arn:aws:iam::005956675899:role/ECS_Pass_Cluster_Management
+ROLE_ARN=${ROLE_ARN:=arn:aws:iam::005956675899:role/ECS_Pass_Cluster_Management}
 ROLE_NAME=pass_mgmt
+
+if [[ ! -z ROLE_PROFILE ]]; then
+  ROLE_PROFILE="--profile $ROLE_PROFILE"
+else
+  ROLE_PROFILE=""
+fi
+
 declare -a ROLE_CREDS
 
 function drop_role()
@@ -27,7 +34,7 @@ function drop_role()
 
 function obtain_role()
 {
-  ROLE_CREDS=($(aws sts assume-role --role-arn ${ROLE_ARN} --role-session-name ${ROLE_NAME} | jq -r '[.Credentials.SessionToken, .Credentials.SecretAccessKey, .Credentials.AccessKeyId] | @sh'))
+  ROLE_CREDS=($(aws sts assume-role ${ROLE_PROFILE} --role-arn ${ROLE_ARN} --role-session-name ${ROLE_NAME} | jq -r '[.Credentials.SessionToken, .Credentials.SecretAccessKey, .Credentials.AccessKeyId] | @sh'))
 }
 
 case $1 in


### PR DESCRIPTION
I needed a way to test against different AWS profiles and ARNs. I
modified the ROLE_ARN variable to access an already set $ROLE_ARN
or use the default that Elliot had set.

Also includes a new option variable called ROLE_PROFILE. If set, it adds
"--profile $ROLE_PROFILE" to the command line. Otherwise, nothign is added.