### PR TITLE
Add Unpaywall integration

### DIFF
--- a/.env
+++ b/.env
@@ -17,14 +17,14 @@ STATIC_HTML_PORT=82
 
 # Static html server build-time config
 STATIC_HTML_GIT_REPO=https://github.com/OA-PASS/pass-ui-static.git
-STATIC_HTML_GIT_BRANCH=cf9e099756b1f40c678b46cc8322502ccb089c07
+STATIC_HTML_GIT_BRANCH=94a846b2d255d1d5188efe3f3bd52ef6b2710b4b
 
 # Ember app runtime config
 EMBER_PORT=81
 
 # Ember app build-time config
 EMBER_GIT_REPO=https://github.com/OA-PASS/pass-ember
-EMBER_GIT_BRANCH=c942e3482b0c714994e75abc858f29cd6a011726
+EMBER_GIT_BRANCH=e2c73d91d380532ed2c60ac76f791b14bbeecd59
 
 EMBER_ROOT_URL=/app/
 

--- a/.env
+++ b/.env
@@ -186,3 +186,11 @@ POLICY_SERVICE_PORT=8088
 # DOI Service
 DOI_SERVICE_URL=/doiservice/journal
 PASS_DOI_SERVICE_PORT=8090
+
+# Open Access manuscript download service
+MANUSCRIPT_SERVICE_LOOKUP_URL=/downloadservice/lookup
+MANUSCRIPT_SERVICE_DOWNLOAD_URL=/downloadservice/download
+DOWNLOAD_SERVICE_PORT=6502
+DOWNLOAD_SERVICE_DEST=http://fcrepo:8080/fcrepo/rest/files
+UNPAYWALL_REQUEST_EMAIL=admin@oa-pass.org
+UNPAYWALL_BASEURI=https://api.unpaywall.org/v2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,8 @@ services:
 
   proxy:
     build: ./httpd-proxy/
-    image: oapass/httpd-proxy:201900508@sha256:a915ada2286a551d32b0494d4ce874ba7fe204c07f029cc9bba5e05b2a9087fc
+    # image: oapass/httpd-proxy:201900508@sha256:a915ada2286a551d32b0494d4ce874ba7fe204c07f029cc9bba5e05b2a9087fc
+    image: oapass/httpd-proxy:moop
     container_name: proxy
     networks:
      - front
@@ -124,7 +125,8 @@ services:
 
   sp:
     build: ./sp/2.6.1
-    image: oapass/sp:20190813@sha256:d75554dd82191ec3201494a2c0db5ba632d0e37141bba6561b5d48fdee916f38
+    # image: oapass/sp:20190813@sha256:d75554dd82191ec3201494a2c0db5ba632d0e37141bba6561b5d48fdee916f38
+    image: oapass/sp:moos
     container_name: sp
     networks:
      - back
@@ -283,6 +285,16 @@ services:
     env_file: .env
     ports:
       - "${PASS_DOI_SERVICE_PORT}:8080"
+    networks:
+      - front
+      - back
+  
+  downloadservice:
+    image: oapass/download-service:latest
+    container_name: downloadservice
+    env_file: .env
+    ports:
+      - "${DOWNLOAD_SERVICE_PORT}:${DOWNLOAD_SERVICE_PORT}"
     networks:
       - front
       - back

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,8 +79,7 @@ services:
 
   proxy:
     build: ./httpd-proxy/
-    # image: oapass/httpd-proxy:201900508@sha256:a915ada2286a551d32b0494d4ce874ba7fe204c07f029cc9bba5e05b2a9087fc
-    image: oapass/httpd-proxy:moop
+    image: oapass/httpd-proxy:20200507@sha256:e8ad2e759fe270998efc80bdcacbeb3f965b4b83d875478e36b0ce4c104bb2d3
     container_name: proxy
     networks:
      - front
@@ -125,8 +124,7 @@ services:
 
   sp:
     build: ./sp/2.6.1
-    # image: oapass/sp:20190813@sha256:d75554dd82191ec3201494a2c0db5ba632d0e37141bba6561b5d48fdee916f38
-    image: oapass/sp:moos
+    image: oapass/sp:20200507@sha256:03d652dc51adf919f6f6982bbb5b32188bd8a8053600271dfe0cf9022c2d31fd
     container_name: sp
     networks:
      - back

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,9 @@ services:
         USER_SERVICE_URL: "${USER_SERVICE_URL}"
         DOI_SERVICE_URL: "${DOI_SERVICE_URL}"
         METADATA_SCHEMA_URI: "${METADATA_SCHEMA_URI}"
-    image: oapass/ember:20200427-c942e34@sha256:08998daf3eb5bdc0fe4f1b0e38d57d1eb8255d53f2bb0c97eb73edcca3b54ad3
+        MANUSCRIPT_SERVICE_LOOKUP_URL: "${MANUSCRIPT_SERVICE_LOOKUP_URL}"
+        MANUSCRIPT_SERVICE_DOWNLOAD_URL: "${MANUSCRIPT_SERVICE_DOWNLOAD_URL}"
+    image: oapass/ember:20200507-e2c73d9@sha256:9df9f7608bde1cc52b34bf66ba31350a62e6d168228e40c4e5a28ef032227b66
     container_name: ember
     env_file: .env
     networks:
@@ -56,7 +58,7 @@ services:
       args:
         STATIC_HTML_GIT_REPO: "${STATIC_HTML_GIT_REPO}"
         STATIC_HTML_GIT_BRANCH: "${STATIC_HTML_GIT_BRANCH}"
-    image: oapass/static-html:jhu-20200504-cf9e099@sha256:d64c25f2110378e80dca9b7b6f23e8bab094198b9f962feb806be3aac6189c42
+    image: oapass/static-html:jhu-20200507-94a846b@sha256:ea00882c1d8d472705be8df439195c30d9562093eb0f2cce9354a230bd91b634
     container_name: static-html
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -288,7 +288,7 @@ services:
       - back
   
   downloadservice:
-    image: oapass/download-service:latest
+    image: oapass/download-service:v1.0.0@sha256:67a4ff5b35ae8b967823b02c17a1e72f04603dd176213fedfa2bf11bbeee1a00
     container_name: downloadservice
     env_file: .env
     ports:

--- a/ember/Dockerfile
+++ b/ember/Dockerfile
@@ -21,7 +21,9 @@ ENV EMBER_GIT_BRANCH=${EMBER_GIT_BRANCH:-master} \
     DOI_SERVICE_URL=${DOI_SERVICE_URL:-/doiservice/journal} \
     POLICY_SERVICE_URL=${POLICY_SERVICE_URL:-/policies} \
     EMBER_ROOT_URL=${EMBER_ROOT_URL:-/app/} \
-    METADATA_SCHEMA_URI=${METADATA_SCHEMA_URI:-https://oa-pass.github.com/metadata-schemas/jhu/global.json}
+    METADATA_SCHEMA_URI=${METADATA_SCHEMA_URI:-https://oa-pass.github.com/metadata-schemas/jhu/global.json} \
+    MANUSCRIPT_SERVICE_LOOKUP_URL=${MANUSCRIPT_SERVICE_LOOKUP_URL:-/downloadservice/lookup} \
+    MANUSCRIPT_SERVICE_DOWNLOAD_URL=${MANUSCRIPT_SERVICE_DOWNLOAD_URL:-/downloadservice/download}
 
 RUN apk add --no-cache git && \
     node -v && npm -v && yarn -v && \

--- a/httpd-proxy/etc-httpd/conf.d/httpd.conf
+++ b/httpd-proxy/etc-httpd/conf.d/httpd.conf
@@ -113,6 +113,10 @@ EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
     ProxyPass /doiservice http://sp/doiservice
     ProxyPassReverse /doiservice http://sp/doiservice
 
+    # OA Manuscript download service
+    ProxyPass /downloadservice http://sp/downloadservice
+    ProxyPassReverse /downloadservice http://sp/downloadservice
+
     # Static pages
     ProxyPass / http://static-html:82/
     ProxyPassReverse / http://static-html:82/

--- a/sp/2.6.1/etc-httpd/conf.d/sp.conf
+++ b/sp/2.6.1/etc-httpd/conf.d/sp.conf
@@ -58,6 +58,13 @@ AllowEncodedSlashes NoDecode
         require shib-session
     </Location>
 
+    <Location /downloadservice>
+        AuthType shibboleth
+        ShibRequestSetting requireSession 1
+        ShibUseHeaders On
+        require shib-session
+    </Location>
+
 
     ProxyPreserveHost on
     RequestHeader set X-Forwarded-Proto "https" env=HTTPS
@@ -84,5 +91,8 @@ AllowEncodedSlashes NoDecode
 
     ProxyPassReverse /doiservice http://doiservice:8080/pass-doi-service
     ProxyPass /doiservice http://doiservice:8080/pass-doi-service
+
+    ProxyPassReverse /downloadservice http://downloadservice:6502
+    ProxyPass /downloadservice http://downloadservice:6502
 
 </VirtualHost>


### PR DESCRIPTION
_Should we spike this PR and add it to `pass-docker` separately?_

* Adds backend download service
* Updates FAQ pages in static-html
* Updates Ember app to use download service to optionally attach a manuscript to a submission, instead of requiring manual upload by the user
* Updates proxy and sp to expose download service

### Download service

This service uses Unpaywall's API to search for existing manuscripts associated with a DOI. It has two endpoints that the Ember app uses that must be made available to the internet

* `/downloadservice/lookup` 
  * The Ember app uses `MANUSCRIPT_SERVICE_LOOKUP_URL=/downloadservice/lookup` in `.env` at build time to configure this
* `/downloadservice/download`
  * The Ember app uses `MANUSCRIPT_SERVICE_DOWNLOAD_URL=/downloadservice/download` in `.env` at build time to configure this
* In the `pass-docker` environment, the download service adds the following env vars in `.env`

```
DOWNLOAD_SERVICE_PORT=6502
DOWNLOAD_SERVICE_DEST=http://fcrepo:8080/fcrepo/rest/files
UNPAYWALL_REQUEST_EMAIL=admin@oa-pass.org
UNPAYWALL_BASEURI=https://api.unpaywall.org/v2
```